### PR TITLE
Add new provider related fields

### DIFF
--- a/controllers/config/parameters.go
+++ b/controllers/config/parameters.go
@@ -216,9 +216,7 @@ func NewXJoinConfiguration() Parameters {
 							"properties": {
 								"fqdn": { "type": "keyword"},
 								"insights_id": { "type": "keyword"},
-								"satellite_id": { "type": "keyword"},
-								"provider_type": { "type": "keyword"},
-								"provider_id": { "type": "keyword"}
+								"satellite_id": { "type": "keyword"}
 							}
 						},
 						"system_profile_facts": {


### PR DESCRIPTION
This adds two new canonical fields into the mapping. Related to this [xjoin-search PR](https://github.com/RedHatInsights/xjoin-search/pull/101)