### PR TITLE
update README for MacOS related steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,17 @@ The operator defines two controllers that reconcile a XJoinPipeline
 6. Login to https://quay.io and https://registry.redhat.io
    - `docker login -u=<quay-username> -p="password" quay.io`
    - `docker login https://registry.redhat.io`
+   - For MacOS, do the following to place the creds in .docker/config.json, which are stored in `"credsStore": "desktop"|"osxkeystore"` and are not available for pulling images from private repos.
+      1. `docker logout quay.io`
+      1. `docker logout registry.redhat.io`
+      1. Remove the "credStore" block from .docker/config.json.
+      1. `docker login -u=<quay-username> -p="password" quay.io`
+      1. `docker login https://registry.redhat.io`
+      - NOTE: Manually creating the `.docker/config.json` and adding `"auth": base64-encoded username:password` does not work.
 
 7. Append the following line into `/etc/hosts`
     ```
+    127.0.0.1 kafka-kafka-0.kafka-kafka-brokers.test.svc
     127.0.0.1 inventory-db xjoin-elasticsearch-es-default.test.svc connect-connect-api.test.svc xjoin-elasticsearch-es-http
     ```
 

--- a/dev/setup-clowder.sh
+++ b/dev/setup-clowder.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 INCLUDE_EXTRA_STUFF=$1
+PLATFORM=`uname -a | cut -f1 -d' '`
 
 function print_start_message() {
   echo -e "\n********************************************************************************"
@@ -81,12 +82,20 @@ if [ -z "$KUBE_SETUP_PATH" ]; then
   echo "Using default kube_setup from github"
   curl https://raw.githubusercontent.com/RedHatInsights/clowder/master/build/kube_setup.sh -o /tmp/kubesetup/kube_setup.sh && chmod +x /tmp/kubesetup/kube_setup.sh
 
-  if [ "$INCLUDE_EXTRA_STUFF" = true ]; then
-    sed -i 's/^install_xjoin_operator//g' ./kube_setup.sh
+  if [[ $PLATFORM == "Darwin" ]]; then
+    if [ "$INCLUDE_EXTRA_STUFF" = true ]; then
+      sed -i '' 's/^install_xjoin_operator//g' ./kube_setup.sh
+    fi
+    sed -i '' 's/^install_cyndi_operator//g' ./kube_setup.sh
+    sed -i '' 's/^install_keda_operator//g' ./kube_setup.sh
+  else
+    if [ "$INCLUDE_EXTRA_STUFF" = true ]; then
+      sed -i 's/^install_xjoin_operator//g' ./kube_setup.sh
+    fi
+    sed -i 's/^install_cyndi_operator//g' ./kube_setup.sh
+    sed -i 's/^install_keda_operator//g' ./kube_setup.sh
   fi
-  
-  sed -i 's/^install_cyndi_operator//g' ./kube_setup.sh
-  sed -i 's/^install_keda_operator//g' ./kube_setup.sh
+
   /tmp/kubesetup/kube_setup.sh
 fi
 


### PR DESCRIPTION
This PR adds MacOS related to steps to deploy `xjoin-search` to minikube using `xjoin-operator`.