### PR TITLE
Case-insensitive tag filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The operator defines two controllers that reconcile a XJoinPipeline
 7. Append the following line into `/etc/hosts`
     ```
     127.0.0.1 kafka-kafka-0.kafka-kafka-brokers.test.svc
-    127.0.0.1 host-inventory-db.test.svc xjoin-elasticsearch-es-default.test.svc connect-connect-api.test.svc xjoin-elasticsearch-es-http
+    127.0.0.1 inventory-db host-inventory-db.test.svc xjoin-elasticsearch-es-default.test.svc connect-connect-api.test.svc xjoin-elasticsearch-es-http
     ```
 
 8. `./dev/setup-clowder.sh`

--- a/config/samples/xjoin_v1alpha1_xjoinindex.yaml
+++ b/config/samples/xjoin_v1alpha1_xjoinindex.yaml
@@ -39,12 +39,5 @@ spec:
           "transformation.parameters": {
             "delimiters": ["/", "="]
           }
-        }, {
-          "transformation": "object_to_array_of_strings",
-          "input.field": "host.tags",
-          "output.field": "host.tags_search_combined",
-          "transformation.parameters": {
-            "delimiters": ["c6509b6d-9646-4122-a16c-f536660c22ee"]
-          }
-      }]
+        }]
     }

--- a/config/samples/xjoin_v1alpha1_xjoinindex.yaml
+++ b/config/samples/xjoin_v1alpha1_xjoinindex.yaml
@@ -39,5 +39,12 @@ spec:
           "transformation.parameters": {
             "delimiters": ["/", "="]
           }
+        }, {
+          "transformation": "object_to_array_of_strings",
+          "input.field": "host.tags",
+          "output.field": "host.tags_search_combined",
+          "transformation.parameters": {
+            "delimiters": ["c6509b6d-9646-4122-a16c-f536660c22ee"]
+          }
       }]
     }

--- a/config/samples/xjoin_v1alpha1_xjoinindex.yaml
+++ b/config/samples/xjoin_v1alpha1_xjoinindex.yaml
@@ -39,5 +39,5 @@ spec:
           "transformation.parameters": {
             "delimiters": ["/", "="]
           }
-        }]
+      }]
     }

--- a/controllers/config/parameters.go
+++ b/controllers/config/parameters.go
@@ -467,7 +467,7 @@ func NewXJoinConfiguration() Parameters {
 					"script": {
 						"lang": "painless",
 						"if": "ctx.tags_structured != null",
-						"source": "ctx.tags_search = ctx.tags_structured.stream().map(t -> { StringBuilder builder = new StringBuilder(); if (t.namespace != null && t.namespace != 'null') { builder.append(t.namespace); } builder.append('/'); builder.append(t.key); builder.append('='); if (t.value != null) { builder.append(t.value); } return builder.toString() }).collect(Collectors.toList()); ctx.tags_search_combined = ctx.tags_search.stream().map(t -> {return t + "c6509b6d-9646-4122-a16c-f536660c22ee" + t.toLowerCase()}).collect(Collectors.toList())"
+						"source": "ctx.tags_search = ctx.tags_structured.stream().map(t -> { StringBuilder builder = new StringBuilder(); if (t.namespace != null && t.namespace != 'null') { builder.append(t.namespace); } builder.append('/'); builder.append(t.key); builder.append('='); if (t.value != null) { builder.append(t.value); } return builder.toString() }).collect(Collectors.toList()); ctx.tags_search_combined = ctx.tags_search.stream().map(t -> {return t + 'c6509b6d-9646-4122-a16c-f536660c22ee' + t.toLowerCase()}).collect(Collectors.toList())"
 					}
 				}]
 			}`,

--- a/controllers/config/parameters.go
+++ b/controllers/config/parameters.go
@@ -299,6 +299,9 @@ func NewXJoinConfiguration() Parameters {
 					  "tags_search": {
 						"type": "keyword"
 					  },
+					  "tags_search_combined": {
+						"type": "keyword"
+					  },
 					  "per_reporter_staleness_flat": {
 						"type": "nested",
 						"properties": {
@@ -464,7 +467,7 @@ func NewXJoinConfiguration() Parameters {
 					"script": {
 						"lang": "painless",
 						"if": "ctx.tags_structured != null",
-						"source": "ctx.tags_search = ctx.tags_structured.stream().map(t -> { StringBuilder builder = new StringBuilder(); if (t.namespace != null && t.namespace != 'null') { builder.append(t.namespace); } builder.append('/'); builder.append(t.key); builder.append('='); if (t.value != null) { builder.append(t.value); } return builder.toString() }).collect(Collectors.toList())"
+						"source": "ctx.tags_search = ctx.tags_structured.stream().map(t -> { StringBuilder builder = new StringBuilder(); if (t.namespace != null && t.namespace != 'null') { builder.append(t.namespace); } builder.append('/'); builder.append(t.key); builder.append('='); if (t.value != null) { builder.append(t.value); } return builder.toString() }).collect(Collectors.toList()); ctx.tags_search_combined = ctx.tags_search.stream().map(t -> {return t + "c6509b6d-9646-4122-a16c-f536660c22ee" + t.toLowerCase()}).collect(Collectors.toList())"
 					}
 				}]
 			}`,

--- a/controllers/config/parameters.go
+++ b/controllers/config/parameters.go
@@ -467,7 +467,7 @@ func NewXJoinConfiguration() Parameters {
 					"script": {
 						"lang": "painless",
 						"if": "ctx.tags_structured != null",
-						"source": "ctx.tags_search = ctx.tags_structured.stream().map(t -> { StringBuilder builder = new StringBuilder(); if (t.namespace != null && t.namespace != 'null') { builder.append(t.namespace); } builder.append('/'); builder.append(t.key); builder.append('='); if (t.value != null) { builder.append(t.value); } return builder.toString() }).collect(Collectors.toList()); ctx.tags_search_combined = ctx.tags_search.stream().map(t -> {return t + 'c6509b6d-9646-4122-a16c-f536660c22ee' + t.toLowerCase()}).collect(Collectors.toList())"
+						"source": "ctx.tags_search = ctx.tags_structured.stream().map(t -> { StringBuilder builder = new StringBuilder(); if (t.namespace != null && t.namespace != 'null') { builder.append(t.namespace); } builder.append('/'); builder.append(t.key); builder.append('='); if (t.value != null) { builder.append(t.value); } return builder.toString() }).collect(Collectors.toList()); ctx.tags_search_combined = ctx.tags_search.stream().map(t -> {return t + 'c6509b6d-9646-4122-a16c-f536660c22ee' + t.toLowerCase()}).collect(Collectors.toList());"
 					}
 				}]
 			}`,

--- a/controllers/data/types.go
+++ b/controllers/data/types.go
@@ -16,4 +16,5 @@ type Host struct {
 	TagsStructured     []map[string]string `json:"tags_structured"`
 	TagsString         []string            `json:"tags_string"`
 	TagsSearch         []string            `json:"tags_search"`
+	TagsSearchCombined []string            `json:"tags_search_combined"`
 }

--- a/deploy/clowder.yaml
+++ b/deploy/clowder.yaml
@@ -171,6 +171,9 @@ objects:
               },
               "tags_search": {
                 "type": "keyword"
+              },
+              "tags_search_combined": {
+                "type": "keyword"
               }
             }
           }}

--- a/deploy/operator.yml
+++ b/deploy/operator.yml
@@ -480,6 +480,9 @@ parameters:
             },
             "tags_search": {
               "type": "keyword"
+            },
+            "tags_search_combined": {
+              "type": "keyword"
             }
           }
         }


### PR DESCRIPTION
Replaces #6. Accompanies [xjoin-search PR 125](https://github.com/RedHatInsights/xjoin-search/pull/125).
Also adds "inventory-db" back into /etc/hosts in the README, since it turns out that's also still needed during the setup process.