### PR TITLE
Add org_id

### DIFF
--- a/config/samples/avroschema.json
+++ b/config/samples/avroschema.json
@@ -15,6 +15,10 @@
       "type": "string"
     },
     {
+      "name": "org_id",
+      "type": "string"
+    },
+    {
       "name": "display_name",
       "type": "string",
       "default": null

--- a/config/samples/xjoin_v1alpha1_xjoindatasource.yaml
+++ b/config/samples/xjoin_v1alpha1_xjoindatasource.yaml
@@ -53,6 +53,13 @@ spec:
           }
         },
         {
+          "name": "org_id",
+          "type": {
+            "type": "string",
+            "xjoin.type": "string"
+          }
+        },
+        {
           "name": "display_name",
           "type": [
             "null",

--- a/controllers/config/parameters.go
+++ b/controllers/config/parameters.go
@@ -214,6 +214,7 @@ func NewXJoinConfiguration() Parameters {
 					  "ingest_timestamp": {"type": "date"},
 					  "id": { "type": "keyword" },
 					  "account": { "type": "keyword" },
+					  "org_id": { "type": "keyword" },
 					  "display_name": {
 						"type": "keyword",
 						"fields": {

--- a/controllers/data/types.go
+++ b/controllers/data/types.go
@@ -3,6 +3,7 @@ package data
 type Host struct {
 	ID                 *string             `json:"id" db:"id"`
 	Account            *string             `json:"account" db:"account"`
+	OrgId              *string             `json:"org_id" db:"org_id"`
 	DisplayName        *string             `json:"display_name" db:"display_name"`
 	CreatedOn          *string             `json:"created_on" db:"created_on"`
 	ModifiedOn         *string             `json:"modified_on" db:"modified_on"`

--- a/controllers/database/database.go
+++ b/controllers/database/database.go
@@ -5,17 +5,18 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+	"text/template"
+	"time"
+
 	"github.com/go-errors/errors"
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
 	"github.com/redhatinsights/xjoin-operator/controllers/data"
 	logger "github.com/redhatinsights/xjoin-operator/controllers/log"
 	"github.com/redhatinsights/xjoin-operator/controllers/utils"
-	"net/url"
-	"sort"
-	"strings"
-	"text/template"
-	"time"
 )
 
 var log = logger.NewLogger("database")
@@ -341,7 +342,7 @@ func formatIdsList(ids []string) (string, error) {
 
 //TODO handle this dynamically with a schema
 func (db *Database) GetHostsByIds(ids []string) ([]data.Host, error) {
-	cols := "id,account,display_name,created_on,modified_on,facts,canonical_facts,system_profile_facts,ansible_host,stale_timestamp,reporter,tags"
+	cols := "id,account,org_id,display_name,created_on,modified_on,facts,canonical_facts,system_profile_facts,ansible_host,stale_timestamp,reporter,tags"
 
 	idsString, err := formatIdsList(ids)
 	if err != nil {

--- a/deploy/clowder.yaml
+++ b/deploy/clowder.yaml
@@ -104,6 +104,7 @@ objects:
               "ingest_timestamp": {"type": "date"},
               "id": { "type": "keyword" },
               "account": { "type": "keyword" },
+              "org_id": { "type": "keyword" },
               "display_name": {
                 "type": "keyword",
                 "fields": {

--- a/deploy/operator.yml
+++ b/deploy/operator.yml
@@ -191,6 +191,9 @@ parameters:
             "account": {
               "type": "keyword"
             },
+            "org_id": {
+              "type": "keyword"
+            },
             "display_name": {
               "type": "keyword",
               "fields": {

--- a/dev/avro.schema.json
+++ b/dev/avro.schema.json
@@ -16,6 +16,10 @@
             "type": "string"
         },
         {
+            "name": "org_id",
+            "type": "string"
+        },
+        {
             "name": "display_name",
             "type": [
                 "null",

--- a/dev/generic.refactor/samples/datasource.avro.json
+++ b/dev/generic.refactor/samples/datasource.avro.json
@@ -18,6 +18,11 @@
       "type": "string"
     },
     {
+      "name": "org_id",
+      "xjoin.name": "org_id",
+      "type": "string"
+    },
+    {
       "name": "display_name",
       "xjoin.name": "display_name",
       "type": [

--- a/dev/insert.hosts.sh
+++ b/dev/insert.hosts.sh
@@ -30,6 +30,7 @@ function add_host() {
   VALUE="(
   '$(uuidgen)',
   '5',
+  '5',
   'test',
   '2017-01-01 00:00:00',
   '$NOW',

--- a/dev/insert.hosts.sh
+++ b/dev/insert.hosts.sh
@@ -19,7 +19,7 @@ function ctrl_c() {
 function add_header() {
   FILE=$1
   SQL_STATEMENT="INSERT INTO hosts
-    (id, account, display_name, created_on, modified_on, facts, tags, canonical_facts, system_profile_facts, stale_timestamp, reporter)
+    (id, account, org_id, display_name, created_on, modified_on, facts, tags, canonical_facts, system_profile_facts, stale_timestamp, reporter)
     VALUES "
   echo "$SQL_STATEMENT" > "$FILE"
 }

--- a/test/hosts/es/display-name-changed.json
+++ b/test/hosts/es/display-name-changed.json
@@ -1,6 +1,7 @@
 {
   "id": "{{.ID}}",
   "account": "5",
+  "org_id": "5",
   "display_name": "test-invalid",
   "created_on": "2017-01-01T00:00:00Z",
   "modified_on": "{{.ModifiedOn}}",

--- a/test/hosts/es/lots-of-changes.json
+++ b/test/hosts/es/lots-of-changes.json
@@ -1,6 +1,7 @@
 {
   "id": "{{.ID}}",
   "account": "8",
+  "org_id": "8",
   "display_name": "testmodified",
   "created_on": "2020-01-01T00:00:00Z",
   "modified_on": "{{.ModifiedOn}}",

--- a/test/hosts/es/simple.json
+++ b/test/hosts/es/simple.json
@@ -1,6 +1,7 @@
 {
   "id": "{{.ID}}",
   "account": "5",
+  "org_id": "5",
   "display_name": "test",
   "created_on": "2017-01-01T00:00:00Z",
   "modified_on": "{{.ModifiedOn}}",

--- a/test/hosts/es/systemprofile-array-of-objects-extra-key.json
+++ b/test/hosts/es/systemprofile-array-of-objects-extra-key.json
@@ -1,6 +1,7 @@
 {
   "id": "{{.ID}}",
   "account": "5",
+  "org_id": "5",
   "display_name": "test",
   "created_on": "2017-01-01T00:00:00Z",
   "modified_on": "{{.ModifiedOn}}",

--- a/test/hosts/es/systemprofile-array-of-objects-extra-object.json
+++ b/test/hosts/es/systemprofile-array-of-objects-extra-object.json
@@ -1,6 +1,7 @@
 {
   "id": "{{.ID}}",
   "account": "5",
+  "org_id": "5",
   "display_name": "test",
   "created_on": "2017-01-01T00:00:00Z",
   "modified_on": "{{.ModifiedOn}}",

--- a/test/hosts/es/systemprofile-array-of-objects-missing-key.json
+++ b/test/hosts/es/systemprofile-array-of-objects-missing-key.json
@@ -1,6 +1,7 @@
 {
   "id": "{{.ID}}",
   "account": "5",
+  "org_id": "5",
   "display_name": "test",
   "created_on": "2017-01-01T00:00:00Z",
   "modified_on": "{{.ModifiedOn}}",

--- a/test/hosts/es/systemprofile-array-of-objects-missing-object.json
+++ b/test/hosts/es/systemprofile-array-of-objects-missing-object.json
@@ -1,6 +1,7 @@
 {
   "id": "{{.ID}}",
   "account": "5",
+  "org_id": "5",
   "display_name": "test",
   "created_on": "2017-01-01T00:00:00Z",
   "modified_on": "{{.ModifiedOn}}",

--- a/test/hosts/es/systemprofile-array-of-objects-value-changed.json
+++ b/test/hosts/es/systemprofile-array-of-objects-value-changed.json
@@ -1,6 +1,7 @@
 {
   "id": "{{.ID}}",
   "account": "5",
+  "org_id": "5",
   "display_name": "test",
   "created_on": "2017-01-01T00:00:00Z",
   "modified_on": "{{.ModifiedOn}}",

--- a/test/hosts/es/systemprofile-boolean-modified.json
+++ b/test/hosts/es/systemprofile-boolean-modified.json
@@ -1,6 +1,7 @@
 {
   "id": "{{.ID}}",
   "account": "5",
+  "org_id": "5",
   "display_name": "test",
   "created_on": "2017-01-01T00:00:00Z",
   "modified_on": "{{.ModifiedOn}}",

--- a/test/hosts/es/systemprofile-extra-simple-array-value.json
+++ b/test/hosts/es/systemprofile-extra-simple-array-value.json
@@ -1,6 +1,7 @@
 {
   "id": "{{.ID}}",
   "account": "5",
+  "org_id": "5",
   "display_name": "test",
   "created_on": "2017-01-01T00:00:00Z",
   "modified_on": "{{.ModifiedOn}}",

--- a/test/hosts/es/systemprofile-integer-modified.json
+++ b/test/hosts/es/systemprofile-integer-modified.json
@@ -1,6 +1,7 @@
 {
   "id": "{{.ID}}",
   "account": "5",
+  "org_id": "5",
   "display_name": "test",
   "created_on": "2017-01-01T00:00:00Z",
   "modified_on": "{{.ModifiedOn}}",

--- a/test/hosts/es/systemprofile-missing-simple-array-value.json
+++ b/test/hosts/es/systemprofile-missing-simple-array-value.json
@@ -1,6 +1,7 @@
 {
   "id": "{{.ID}}",
   "account": "5",
+  "org_id": "5",
   "display_name": "test",
   "created_on": "2017-01-01T00:00:00Z",
   "modified_on": "{{.ModifiedOn}}",

--- a/test/hosts/es/systemprofile-object-array-value-changed.json
+++ b/test/hosts/es/systemprofile-object-array-value-changed.json
@@ -1,6 +1,7 @@
 {
   "id": "{{.ID}}",
   "account": "5",
+  "org_id": "5",
   "display_name": "test",
   "created_on": "2017-01-01T00:00:00Z",
   "modified_on": "{{.ModifiedOn}}",

--- a/test/hosts/es/systemprofile-object-key-added.json
+++ b/test/hosts/es/systemprofile-object-key-added.json
@@ -1,6 +1,7 @@
 {
   "id": "{{.ID}}",
   "account": "5",
+  "org_id": "5",
   "display_name": "test",
   "created_on": "2017-01-01T00:00:00Z",
   "modified_on": "{{.ModifiedOn}}",

--- a/test/hosts/es/systemprofile-object-key-removed.json
+++ b/test/hosts/es/systemprofile-object-key-removed.json
@@ -1,6 +1,7 @@
 {
   "id": "{{.ID}}",
   "account": "5",
+  "org_id": "5",
   "display_name": "test",
   "created_on": "2017-01-01T00:00:00Z",
   "modified_on": "{{.ModifiedOn}}",

--- a/test/hosts/es/systemprofile-object-missing.json
+++ b/test/hosts/es/systemprofile-object-missing.json
@@ -1,6 +1,7 @@
 {
   "id": "{{.ID}}",
   "account": "5",
+  "org_id": "5",
   "display_name": "test",
   "created_on": "2017-01-01T00:00:00Z",
   "modified_on": "{{.ModifiedOn}}",

--- a/test/hosts/es/systemprofile-object-value-changed.json
+++ b/test/hosts/es/systemprofile-object-value-changed.json
@@ -1,6 +1,7 @@
 {
   "id": "{{.ID}}",
   "account": "5",
+  "org_id": "5",
   "display_name": "test",
   "created_on": "2017-01-01T00:00:00Z",
   "modified_on": "{{.ModifiedOn}}",

--- a/test/hosts/es/systemprofile-top-level-key-added.json
+++ b/test/hosts/es/systemprofile-top-level-key-added.json
@@ -1,6 +1,7 @@
 {
   "id": "{{.ID}}",
   "account": "5",
+  "org_id": "5",
   "display_name": "test",
   "created_on": "2017-01-01T00:00:00Z",
   "modified_on": "{{.ModifiedOn}}",

--- a/test/hosts/es/systemprofile-top-level-key-modified.json
+++ b/test/hosts/es/systemprofile-top-level-key-modified.json
@@ -1,6 +1,7 @@
 {
   "id": "{{.ID}}",
   "account": "5",
+  "org_id": "5",
   "display_name": "test",
   "created_on": "2017-01-01T00:00:00Z",
   "modified_on": "{{.ModifiedOn}}",

--- a/test/hosts/es/tags-multiple-unordered.json
+++ b/test/hosts/es/tags-multiple-unordered.json
@@ -1,6 +1,7 @@
 {
   "id": "{{.ID}}",
   "account": "5",
+  "org_id": "5",
   "display_name": "test",
   "created_on": "2017-01-01T00:00:00Z",
   "modified_on": "{{.ModifiedOn}}",

--- a/test/hosts/es/tags-string-modified.json
+++ b/test/hosts/es/tags-string-modified.json
@@ -1,6 +1,7 @@
 {
   "id": "{{.ID}}",
   "account": "5",
+  "org_id": "5",
   "display_name": "test",
   "created_on": "2017-01-01T00:00:00Z",
   "modified_on": "{{.ModifiedOn}}",

--- a/test/hosts/es/tags-structured-key-modified.json
+++ b/test/hosts/es/tags-structured-key-modified.json
@@ -1,6 +1,7 @@
 {
   "id": "{{.ID}}",
   "account": "5",
+  "org_id": "5",
   "display_name": "test",
   "created_on": "2017-01-01T00:00:00Z",
   "modified_on": "{{.ModifiedOn}}",

--- a/test/hosts/es/tags-structured-namespace-modified.json
+++ b/test/hosts/es/tags-structured-namespace-modified.json
@@ -1,6 +1,7 @@
 {
   "id": "{{.ID}}",
   "account": "5",
+  "org_id": "5",
   "display_name": "test",
   "created_on": "2017-01-01T00:00:00Z",
   "modified_on": "{{.ModifiedOn}}",

--- a/test/hosts/es/tags-structured-value-modified.json
+++ b/test/hosts/es/tags-structured-value-modified.json
@@ -1,6 +1,7 @@
 {
   "id": "{{.ID}}",
   "account": "5",
+  "org_id": "5",
   "display_name": "test",
   "created_on": "2017-01-01T00:00:00Z",
   "modified_on": "{{.ModifiedOn}}",

--- a/test/hosts/hbi/simple.sql
+++ b/test/hosts/hbi/simple.sql
@@ -1,6 +1,7 @@
 INSERT INTO hosts (
     id,
     account,
+    org_id,
     display_name,
     created_on,
     modified_on,
@@ -12,6 +13,7 @@ INSERT INTO hosts (
     reporter)
 VALUES (
     '{{.ID}}',
+    '5',
     '5',
     'test',
     '2017-01-01 00:00:00',

--- a/test/hosts/hbi/systemprofile-top-level-key-added.sql
+++ b/test/hosts/hbi/systemprofile-top-level-key-added.sql
@@ -1,6 +1,7 @@
 INSERT INTO hosts (
     id,
     account,
+    org_id,
     display_name,
     created_on,
     modified_on,
@@ -12,6 +13,7 @@ INSERT INTO hosts (
     reporter)
 VALUES (
     '{{.ID}}',
+    '5',
     '5',
     'test',
     '2017-01-01 00:00:00',

--- a/test/hosts/hbi/tags-multiple-unordered.sql
+++ b/test/hosts/hbi/tags-multiple-unordered.sql
@@ -1,6 +1,7 @@
 INSERT INTO hosts (
     id,
     account,
+    org_id,
     display_name,
     created_on,
     modified_on,
@@ -12,6 +13,7 @@ INSERT INTO hosts (
     reporter)
 VALUES (
     '{{.ID}}',
+    '5',
     '5',
     'test',
     '2017-01-01 00:00:00',


### PR DESCRIPTION
We need `org_id` to match our implementation for `account`, so this PR adds `org_id` accordingly.