### PR TITLE
ESSNL-4062 add pr_check to xjoin-operator project

### DIFF
--- a/Dockerfile.4unittest
+++ b/Dockerfile.4unittest
@@ -1,0 +1,5 @@
+FROM registry.access.redhat.com/ubi8/go-toolset:1.17.12
+
+WORKDIR /workspace
+
+COPY . .

--- a/controllers/test_utils.go
+++ b/controllers/test_utils.go
@@ -1,10 +1,11 @@
 package controllers
 
 import (
+	"time"
+
 	"github.com/go-errors/errors"
 	. "github.com/onsi/gomega"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"time"
 )
 
 var K8sGetTimeout = 3 * time.Second
@@ -12,7 +13,7 @@ var K8sGetInterval = 100 * time.Millisecond
 
 var testLogger = logf.Log.WithName("test")
 
-//this is used to output stack traces when an error occurs
+// this is used to output stack traces when an error occurs
 func checkError(err error) {
 	if err != nil {
 		testLogger.Error(errors.Wrap(err, 0), "test failure")

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+go version
+
+# including number of comments as it was used by clowder.
+while read line; do
+    if [ ${#line} -ge 100 ]; then
+        echo "Commit messages are limited to 100 characters."
+        echo "The following commit message has ${#line} characters."
+        echo "${line}"
+        exit 1
+    fi
+done <<< "$(git log --pretty=format:%s $(git merge-base master HEAD)..HEAD)"
+
+set -exv
+
+IMAGE_TAG=`cat go.mod go.sum Dockerfile | sha256sum  | head -c 7`
+TEST_IMAGE="xjoin-operator-unit-"$IMAGE_TAG
+
+# check container engine type
+podman_state=`systemctl show --property ActiveState podman`
+docker_state=`systemctl show --property ActiveState docker`
+
+if grep -iqw "active" <<< $podman_state; then
+    CONTAINER_ENGINE='podman'
+elif grep -iqw "active" <<< $docker_state; then
+    CONTAINER_ENGINE='docker'
+else
+    echo "No container engine running"
+fi
+
+echo "Active container engine: $CONTAINER_ENGINE"
+
+$CONTAINER_ENGINE build -t $TEST_IMAGE -f Dockerfile.4unittest . 
+$CONTAINER_ENGINE run -i -u0 $TEST_IMAGE bash -c "make generic-test"
+TEST_RESULT=$?
+
+if [[ $TEST_RESULT -ne 0 ]]; then
+    echo "Test encountered problems"
+    exit $TEST_RESULT
+else
+    echo "Unit tests SUCCESSFUL"
+fi
+
+exit $TEST_RESULT


### PR DESCRIPTION
This pr_check creates a test container and runs unit tests.  The unit tests are run using mocks and does not require minikube.