### PR TITLE
chore(dev): poman secrets and cleanup fixes

### DIFF
--- a/dev/cleanup.projects.sh
+++ b/dev/cleanup.projects.sh
@@ -12,8 +12,7 @@ done
 echo "Deleting namespaces.."
 kubectl get namespaces -o custom-columns=name:metadata.name | grep xjointest | while read -r namespace ; do
     echo "$namespace"
-    kubectl get XJoinPipeline test-pipeline-01 -o=json -n "$namespace" | jq '.metadata.finalizers = null' | kubectl apply -f -
-    
+    kubectl patch XJoinPipeline test-pipeline-01 -n "$namespace" -p '{"metadata":{"finalizers":[]}}' --type=merge
     kubectl delete namespace "$namespace"
 done
 

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -126,7 +126,12 @@ fi
 PULL_SECRET=cloudservices-pull-secret
 if [ "$SETUP_PULL_SECRET" = true ] || [ "$SETUP_ALL" = true ]; then
   echo "Setting up pull secret"
-  kubectl create secret generic "$PULL_SECRET" --from-file=.dockerconfigjson="$HOME/.docker/config.json" --type=kubernetes.io/dockerconfigjson -n "$PROJECT_NAME"
+  SECRETS_CONFIG="$HOME/.docker/config.json"
+  if [ ! -f "$SECRETS_CONFIG" ]; then
+    # Grab podman's config instead
+    SECRETS_CONFIG="${XDG_RUNTIME_DIR}/containers/auth.json"
+  fi
+  kubectl create secret generic "$PULL_SECRET" --from-file=.dockerconfigjson="$SECRETS_CONFIG" --type=kubernetes.io/dockerconfigjson -n "$PROJECT_NAME"
   kubectl patch serviceaccount default -p "{\"imagePullSecrets\": [{\"name\": \"$PULL_SECRET\"}]}" -n "$PROJECT_NAME"
 fi
 


### PR DESCRIPTION
Support podman's secrets file to create pull secrets on local cluster from.
Use `patch` instead of `apply` on xjoinpipelines when deleting namespace in projects cleanup.