### PR TITLE
refactor: use time.RFC3339Nano format

### DIFF
--- a/controllers/database/database.go
+++ b/controllers/database/database.go
@@ -309,7 +309,7 @@ func (db *Database) GetHostIdsByIdList(ids []string) ([]string, error) {
 func (db *Database) GetHostIdsByModifiedOn(start time.Time, end time.Time) ([]string, error) {
 	query := fmt.Sprintf(
 		`SELECT id FROM hosts WHERE modified_on > '%s' AND modified_on < '%s' ORDER BY id `,
-		start.Format(utils.TimeFormat()), end.Format(utils.TimeFormat()))
+		start.Format(time.RFC3339Nano), end.Format(time.RFC3339Nano))
 
 	log.Info("GetHostIdsQuery", "query", query)
 

--- a/controllers/elasticsearch/data.go
+++ b/controllers/elasticsearch/data.go
@@ -4,14 +4,15 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/elastic/go-elasticsearch/v7/esapi"
-	"github.com/redhatinsights/xjoin-go-lib/pkg/utils"
-	"github.com/redhatinsights/xjoin-operator/controllers/data"
 	"io/ioutil"
 	"math"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/elastic/go-elasticsearch/v7/esapi"
+	"github.com/redhatinsights/xjoin-go-lib/pkg/utils"
+	"github.com/redhatinsights/xjoin-operator/controllers/data"
 )
 
 func (es *ElasticSearch) GetHostsByIds(index string, hostIds []string) ([]data.Host, error) {
@@ -172,8 +173,8 @@ func (es *ElasticSearch) GetHostIDsByIdList(index string, ids []string) (complet
 
 func (es *ElasticSearch) GetHostIDsByModifiedOn(index string, start time.Time, end time.Time) ([]string, error) {
 	var query QueryHostIDsRange
-	query.Query.Range.ModifiedOn.Lt = end.Format(utils.TimeFormat())
-	query.Query.Range.ModifiedOn.Gt = start.Format(utils.TimeFormat())
+	query.Query.Range.ModifiedOn.Lt = end.UTC().Format(time.RFC3339Nano)
+	query.Query.Range.ModifiedOn.Gt = start.UTC().Format(time.RFC3339Nano)
 	reqJSON, err := json.Marshal(query)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Standardize timeformat on [`time.RFC3339Nano`](https://pkg.go.dev/time@go1.18#pkg-constants).

Previous format was [`2006-01-02T15:04:05.999999999`](https://github.com/RedHatInsights/xjoin-go-lib/blob/24227803ebad47655e6a3b3eb6ab3987bed0478c/pkg/utils/lang.go#L100).

References: 
* https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html
* https://www.postgresql.org/docs/13/datatype-datetime.html

ESSNTL-4192