### PR TITLE
refactor: use math.Abs instead

### DIFF
--- a/controllers/pipeline/iteration.go
+++ b/controllers/pipeline/iteration.go
@@ -2,6 +2,10 @@ package pipeline
 
 import (
 	"fmt"
+	"math"
+	"strings"
+	"time"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/redhatinsights/xjoin-go-lib/pkg/utils"
 	xjoin "github.com/redhatinsights/xjoin-operator/api/v1alpha1"
@@ -19,8 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"strings"
-	"time"
 )
 
 // XJoinPipelineReconciler reconciles a XJoinPipeline object
@@ -388,7 +390,7 @@ func (i *ReconcileIteration) UpdateAliasIfHealthier() error {
 			return fmt.Errorf("failed to get host count from latest index %w", err)
 		}
 
-		if utils.Abs(hbiHostCount-latestCount) > utils.Abs(hbiHostCount-activeCount) {
+		if math.Abs(float64(hbiHostCount-latestCount)) > math.Abs(float64(hbiHostCount-activeCount)) {
 			return nil // the active table is healthier; do not update anything
 		}
 	}

--- a/controllers/pipeline/validate.go
+++ b/controllers/pipeline/validate.go
@@ -3,17 +3,18 @@ package pipeline
 import (
 	"errors"
 	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/go-test/deep"
 	"github.com/redhatinsights/xjoin-go-lib/pkg/utils"
 	xjoin "github.com/redhatinsights/xjoin-operator/api/v1alpha1"
 	"github.com/redhatinsights/xjoin-operator/controllers/data"
 	"github.com/redhatinsights/xjoin-operator/controllers/metrics"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"math"
-	"strconv"
-	"strings"
-	"sync"
-	"time"
 )
 
 const countMismatchThreshold = 0.5
@@ -79,8 +80,9 @@ func (i *ReconcileIteration) countValidation() (isValid bool, mismatchCount int,
 
 	metrics.ESHostCount(esCount)
 
-	mismatchCount = utils.Abs(hostCount - esCount)
-	mismatchRatio = float64(mismatchCount) / math.Max(float64(hostCount), 1)
+	diff := math.Abs(float64(hostCount - esCount))
+	mismatchCount = int(diff)
+	mismatchRatio = diff / math.Max(float64(hostCount), 1)
 
 	i.Log.Info("Fetched host counts", "hbi", hostCount,
 		"es", esCount, "mismatchRatio", mismatchRatio)


### PR DESCRIPTION
standard math functions should be preferred

ESSNTL-4192