### PR TITLE
[ESSNTL-4204] Continue scrubbing after single component deletion fails

### DIFF
--- a/controllers/datasource/datasource_reconciler.go
+++ b/controllers/datasource/datasource_reconciler.go
@@ -76,7 +76,7 @@ func (d *ReconcileMethods) RefreshComplete() (err error) {
 	return
 }
 
-func (d *ReconcileMethods) Scrub() (err error) {
+func (d *ReconcileMethods) Scrub() (errs []error) {
 	var validVersions []string
 	if d.iteration.GetInstance().Status.ActiveVersion != "" {
 		validVersions = append(validVersions, d.iteration.GetInstance().Status.ActiveVersion)
@@ -131,9 +131,5 @@ func (d *ReconcileMethods) Scrub() (err error) {
 	custodian.AddComponent(&components.DebeziumConnector{
 		KafkaClient: kafkaClient,
 	})
-	err = custodian.Scrub()
-	if err != nil {
-		return errors.Wrap(err, 0)
-	}
-	return
+	return custodian.Scrub()
 }

--- a/controllers/index/index_reconciler.go
+++ b/controllers/index/index_reconciler.go
@@ -80,7 +80,7 @@ func (d *ReconcileMethods) RefreshComplete() (err error) {
 	return
 }
 
-func (d *ReconcileMethods) Scrub() (err error) {
+func (d *ReconcileMethods) Scrub() (errs []error) {
 	var validVersions []string
 	if d.iteration.GetInstance().Status.ActiveVersion != "" {
 		validVersions = append(validVersions, d.iteration.GetInstance().Status.ActiveVersion)
@@ -106,7 +106,7 @@ func (d *ReconcileMethods) Scrub() (err error) {
 		Context:    d.iteration.Context,
 	})
 	if err != nil {
-		return errors.Wrap(err, 0)
+		return append(errs, errors.Wrap(err, 0))
 	}
 
 	schemaRegistryConnectionParams := schemaregistry.ConnectionParams{
@@ -163,9 +163,5 @@ func (d *ReconcileMethods) Scrub() (err error) {
 		Registry:  registryConfluentClient,
 		Namespace: d.iteration.GetInstance().Namespace,
 	})
-	err = custodian.Scrub()
-	if err != nil {
-		return errors.Wrap(err, 0)
-	}
-	return
+	return custodian.Scrub()
 }

--- a/controllers/index/xjoinindexvalidator_iteration.go
+++ b/controllers/index/xjoinindexvalidator_iteration.go
@@ -97,6 +97,8 @@ func (i *XJoinIndexValidatorIteration) ReconcileValidationPod() (phase string, e
 		if err != nil {
 			return "", errors.Wrap(err, 0)
 		}
+
+		return ValidatorPodRunning, nil
 	}
 
 	//parse the results of the xjoin-validation pod

--- a/controllers/parameters/index_parameters.go
+++ b/controllers/parameters/index_parameters.go
@@ -177,7 +177,7 @@ func BuildIndexParameters() *IndexParameters {
 			Type:          reflect.Int,
 			ConfigMapKey:  "validation.pod.status.interval",
 			ConfigMapName: "xjoin-generic",
-			DefaultValue:  1,
+			DefaultValue:  5,
 		},
 	}
 

--- a/controllers/xjoinindexvalidator_controller.go
+++ b/controllers/xjoinindexvalidator_controller.go
@@ -20,6 +20,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"time"
 )
@@ -67,6 +68,7 @@ func (r *XJoinIndexValidatorReconciler) SetupWithManager(mgr ctrl.Manager) error
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("xjoin-indexvalidator-controller").
 		For(&xjoin.XJoinIndexValidator{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		WithLogConstructor(logConstructor).
 		WithOptions(controller.Options{
 			LogConstructor: logConstructor,

--- a/controllers/xjoinindexvalidator_controller_test.go
+++ b/controllers/xjoinindexvalidator_controller_test.go
@@ -175,7 +175,7 @@ var _ = Describe("XJoinIndexValidator", func() {
 				PodLogReader:   &mocks.LogReader{},
 			}
 			_, result := reconciler.ReconcileCreate()
-			Expect(result).To(Equal(reconcile.Result{Requeue: false, RequeueAfter: 1 * time.Second}))
+			Expect(result).To(Equal(reconcile.Result{Requeue: false, RequeueAfter: 5 * time.Second}))
 		})
 	})
 
@@ -189,7 +189,7 @@ var _ = Describe("XJoinIndexValidator", func() {
 				PodLogReader:   &mocks.LogReader{},
 			}
 			validator, result := reconciler.ReconcileRunning()
-			Expect(result).To(Equal(reconcile.Result{Requeue: false, RequeueAfter: 1 * time.Second}))
+			Expect(result).To(Equal(reconcile.Result{Requeue: false, RequeueAfter: 5 * time.Second}))
 			Expect(validator.Status.ValidationPodPhase).To(Equal(index.ValidatorPodRunning))
 		})
 


### PR DESCRIPTION
Without this fix, when a component deletion fails, e.g. when apicurio is unavailable, then the entire scrub method aborts. This lead to some components never being deleted.