### PR TITLE
Fix deprecated functions from package `io/ioutil`

### DIFF
--- a/controllers/elasticsearch/alias.go
+++ b/controllers/elasticsearch/alias.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"github.com/elastic/go-elasticsearch/v7/esapi"
 	"github.com/redhatinsights/xjoin-go-lib/pkg/utils"
-	"io/ioutil"
+	"io"
 	"strconv"
 )
 
@@ -78,7 +78,7 @@ func (es *ElasticSearch) GetCurrentIndicesWithAlias(name string) ([]string, erro
 		return nil, err
 	}
 
-	byteValue, _ := ioutil.ReadAll(res.Body)
+	byteValue, _ := io.ReadAll(res.Body)
 
 	if res.StatusCode != 200 {
 		return nil, fmt.Errorf(

--- a/controllers/elasticsearch/data.go
+++ b/controllers/elasticsearch/data.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"sort"
 	"strings"
@@ -39,7 +39,7 @@ func (es *ElasticSearch) GetHostsByIds(index string, hostIds []string) ([]data.H
 		return nil, err
 	}
 	if searchRes.StatusCode >= 400 {
-		bodyBytes, _ := ioutil.ReadAll(searchRes.Body)
+		bodyBytes, _ := io.ReadAll(searchRes.Body)
 
 		return nil, fmt.Errorf(
 			"invalid response code when getting hosts by id. StatusCode: %v, Body: %s",
@@ -92,7 +92,7 @@ func (es *ElasticSearch) getHostIDsQuery(index string, reqJSON []byte) ([]string
 	}
 
 	if searchRes.StatusCode >= 400 {
-		bodyBytes, _ := ioutil.ReadAll(searchRes.Body)
+		bodyBytes, _ := io.ReadAll(searchRes.Body)
 
 		return nil, fmt.Errorf(
 			"invalid response code when getting hosts ids. StatusCode: %v, Body: %s",
@@ -188,7 +188,7 @@ func (es *ElasticSearch) GetHostIDsByModifiedOn(index string, start time.Time, e
 func parseSearchHostsResponse(res *esapi.Response) ([]data.Host, error) {
 	var hosts []data.Host
 	var searchHostsJSON SearchHostsResponse
-	byteValue, _ := ioutil.ReadAll(res.Body)
+	byteValue, _ := io.ReadAll(res.Body)
 	err := json.Unmarshal(byteValue, &searchHostsJSON)
 	if err != nil {
 		return nil, err
@@ -204,7 +204,7 @@ func parseSearchHostsResponse(res *esapi.Response) ([]data.Host, error) {
 func parseSearchIdsResponse(scrollRes *esapi.Response) ([]string, SearchIDsResponse, error) {
 	var ids []string
 	var searchJSON SearchIDsResponse
-	byteValue, _ := ioutil.ReadAll(scrollRes.Body)
+	byteValue, _ := io.ReadAll(scrollRes.Body)
 	err := json.Unmarshal(byteValue, &searchJSON)
 	if err != nil {
 		return nil, searchJSON, err

--- a/controllers/elasticsearch/elasticsearch-generic.go
+++ b/controllers/elasticsearch/elasticsearch-generic.go
@@ -8,7 +8,7 @@ import (
 	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/elastic/go-elasticsearch/v7/esapi"
 	"github.com/go-errors/errors"
-	"io/ioutil"
+	"io"
 	"strconv"
 	"strings"
 	"text/template"
@@ -99,7 +99,7 @@ func (es GenericElasticsearch) ListIndicesForPrefix(prefix string) ([]string, er
 	}
 	defer res.Body.Close()
 
-	byteValue, _ := ioutil.ReadAll(res.Body)
+	byteValue, _ := io.ReadAll(res.Body)
 
 	var indicesJSON []map[string]string
 	err = json.Unmarshal(byteValue, &indicesJSON)

--- a/controllers/elasticsearch/elasticsearch.go
+++ b/controllers/elasticsearch/elasticsearch.go
@@ -8,7 +8,7 @@ import (
 	"github.com/elastic/go-elasticsearch/v7/esapi"
 	"github.com/go-errors/errors"
 	logger "github.com/redhatinsights/xjoin-operator/controllers/log"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 )
@@ -64,7 +64,7 @@ func (es *ElasticSearch) SetResourceNamePrefix(updatedPrefix string) {
 func parseResponse(res *esapi.Response) (int, map[string]interface{}, error) {
 	defer res.Body.Close()
 	if res.IsError() {
-		bodyBytes, err := ioutil.ReadAll(res.Body)
+		bodyBytes, err := io.ReadAll(res.Body)
 		if err != nil {
 			return -1, nil, errors.Wrap(err, 0)
 		}
@@ -72,7 +72,7 @@ func parseResponse(res *esapi.Response) (int, map[string]interface{}, error) {
 			fmt.Sprintf("Elasticsearch API error: %s, %s", strconv.Itoa(res.StatusCode), string(bodyBytes))), 0)
 	}
 
-	bodyBytes, err := ioutil.ReadAll(res.Body)
+	bodyBytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		return -1, nil, errors.Wrap(err, 0)
 	}

--- a/controllers/elasticsearch/index.go
+++ b/controllers/elasticsearch/index.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"github.com/elastic/go-elasticsearch/v7/esapi"
 	"github.com/redhatinsights/xjoin-go-lib/pkg/utils"
-	"io/ioutil"
+	"io"
 	"strings"
 	"text/template"
 )
@@ -97,7 +97,10 @@ func (es *ElasticSearch) ListIndices() ([]string, error) {
 		return nil, err
 	}
 
-	byteValue, _ := ioutil.ReadAll(res.Body)
+	byteValue, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
 
 	var indicesJSON []map[string]string
 	err = json.Unmarshal(byteValue, &indicesJSON)
@@ -127,7 +130,10 @@ func (es *ElasticSearch) CountIndex(index string) (int, error) {
 	}
 
 	var countIDsResponse CountIDsResponse
-	byteValue, _ := ioutil.ReadAll(res.Body)
+	byteValue, err := io.ReadAll(res.Body)
+	if err != nil {
+		return -1, err
+	}
 	err = json.Unmarshal(byteValue, &countIDsResponse)
 	if err != nil {
 		return -1, err

--- a/controllers/kafka/managed-topics.go
+++ b/controllers/kafka/managed-topics.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/redhatinsights/xjoin-go-lib/pkg/utils"
 	"golang.org/x/oauth2/clientcredentials"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -270,7 +270,7 @@ func parseResponse(res *http.Response) (int, []byte, error) {
 	defer res.Body.Close()
 
 	if res.StatusCode >= 300 {
-		bodyBytes, err := ioutil.ReadAll(res.Body)
+		bodyBytes, err := io.ReadAll(res.Body)
 		if err != nil {
 			return res.StatusCode, nil, errors.Wrap(err, 0)
 		}
@@ -278,7 +278,7 @@ func parseResponse(res *http.Response) (int, []byte, error) {
 			fmt.Sprintf("Manged Kafka API error: %s, %s", strconv.Itoa(res.StatusCode), string(bodyBytes))), 0)
 	}
 
-	bodyBytes, err := ioutil.ReadAll(res.Body)
+	bodyBytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		return res.StatusCode, nil, errors.Wrap(err, 0)
 	}

--- a/controllers/kafka/strimzi-connectors.go
+++ b/controllers/kafka/strimzi-connectors.go
@@ -9,7 +9,7 @@ import (
 	"github.com/redhatinsights/xjoin-go-lib/pkg/utils"
 	"github.com/redhatinsights/xjoin-operator/controllers/database"
 	"github.com/redhatinsights/xjoin-operator/controllers/metrics"
-	"io/ioutil"
+	"io"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"net/http"
@@ -128,7 +128,7 @@ func (c *StrimziConnectors) GetTaskStatus(connectorName string, taskId float64) 
 		return nil, err
 	}
 	defer res.Body.Close()
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +243,7 @@ func (c *StrimziConnectors) CheckIfConnectIsResponding() (bool, error) {
 		}
 
 		if res != nil && res.StatusCode == 200 {
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			if err != nil {
 				return false, err
 			}
@@ -301,7 +301,7 @@ func (c *StrimziConnectors) ListConnectorsREST(prefix string) ([]string, error) 
 
 	var connectors []string
 	if res.StatusCode == 200 {
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		if err != nil {
 			return nil, err
 		}
@@ -421,7 +421,7 @@ func (c *StrimziConnectors) GetConnectorStatus(connectorName string) (map[string
 	var bodyMap map[string]interface{}
 	if res.StatusCode == 200 {
 		log.Info("Successfully got status for url: " + url)
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		if err != nil {
 			return nil, err
 		}

--- a/controllers/schemaregistry/rest_client.go
+++ b/controllers/schemaregistry/rest_client.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/go-errors/errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -45,7 +45,7 @@ func (c *RestClient) MakeRequest(requestParams Request) (resCode int, body map[s
 		return 500, nil, errors.Wrap(err, 0)
 	}
 
-	resBody, err := ioutil.ReadAll(res.Body)
+	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		return 500, nil, errors.Wrap(err, 0)
 	}

--- a/controllers/test/iteration_test.go
+++ b/controllers/test/iteration_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/redhatinsights/xjoin-operator/controllers/elasticsearch"
 	"github.com/redhatinsights/xjoin-operator/controllers/kafka"
 	k8sUtils "github.com/redhatinsights/xjoin-operator/controllers/utils"
-	"io/ioutil"
+	"io"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -31,6 +31,7 @@ import (
 	"strings"
 	"text/template"
 	"time"
+	"os"
 )
 
 var ResourceNamePrefix = "xjointest"
@@ -102,7 +103,7 @@ func (i *Iteration) getConnectorConfig(connectorName string) (map[string]interfa
 		return nil, errors.New(fmt.Sprintf("invalid response code during getConnectorConfig: %v", res.StatusCode))
 	}
 	defer res.Body.Close()
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -430,7 +431,7 @@ func (i *Iteration) IndexDocumentNow(pipelineVersion string, id string, filename
 }
 
 func (i *Iteration) IndexDocument(pipelineVersion string, id string, filename string, modifiedOn time.Time) error {
-	esDocumentFile, err := ioutil.ReadFile(GetRootDir() + "/test/data/hosts/es/" + filename + ".json")
+	esDocumentFile, err := os.ReadFile(GetRootDir() + "/test/data/hosts/es/" + filename + ".json")
 	if err != nil {
 		return err
 	}
@@ -469,7 +470,7 @@ func (i *Iteration) IndexDocument(pipelineVersion string, id string, filename st
 
 	if res.IsError() {
 
-		bodyBytes, err := ioutil.ReadAll(res.Body)
+		bodyBytes, err := io.ReadAll(res.Body)
 		if err != nil {
 			return err
 		}
@@ -502,7 +503,7 @@ func (i *Iteration) InsertHost(filename string, modifiedOn time.Time) (string, e
 		return "", err
 	}
 
-	hbiHostFile, err := ioutil.ReadFile(GetRootDir() + "/test/data/hosts/hbi/" + filename + ".sql")
+	hbiHostFile, err := os.ReadFile(GetRootDir() + "/test/data/hosts/hbi/" + filename + ".sql")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
As of Go 1.16, the same functionality is now provided by package `io` or `os`, and those implementations should be preferred in new code.

