### PR TITLE
Put back the leftover dummy and whitelist

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,5 +1,5 @@
-[allowlist]
-  description = "Allowlist"
+[whitelist]
+  description = "whitelist"
   paths = [
     '''controllers/parameters''',
     '''controllers/config''',

--- a/config/crd/bases/monitoring.coreos.com_prometheuses.yaml
+++ b/config/crd/bases/monitoring.coreos.com_prometheuses.yaml
@@ -3913,7 +3913,7 @@ spec:
                         parameters.
                       properties:
                         batchSendDeadline:
-                          description: BatchSendDeadline is the maximum time a sample
+                          description: BatchSendDeadline is the maximum time a dummy
                             will wait in buffer.
                           type: string
                         capacity:


### PR DESCRIPTION
This PR removes the leftover sample and allowlist, which should have been removed by dummy and whitelist by the revert of PR but did not.  With this merge, the rude words will be fully back in and the number of changed files in PR #39 will go down to 3.