### PR TITLE
Updated comments reformatted by running dlv execution

### DIFF
--- a/controllers/components/custodian.go
+++ b/controllers/components/custodian.go
@@ -25,8 +25,9 @@ func (c *Custodian) AddComponent(component Component) {
 }
 
 // Scrub removes any components not in validVersions.
-//       When a removal fails it continues scrubbing.
-//       Each error is returned when the scrubbing is complete.
+//
+//	When a removal fails it continues scrubbing.
+//	Each error is returned when the scrubbing is complete.
 func (c *Custodian) Scrub() (allErrors []error) {
 	for _, component := range c.components {
 		installedVersions, err := component.ListInstalledVersions()

--- a/controllers/config/parameters.go
+++ b/controllers/config/parameters.go
@@ -14,7 +14,7 @@ var secretTypes = secrets{
 	schemaRegistry: "schemaregistry",
 }
 
-//Parameters are the xjoin.v1 parameters
+// Parameters are the xjoin.v1 parameters
 type Parameters struct {
 	Ephemeral                            Parameter
 	ResourceNamePrefix                   Parameter

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -40,7 +40,7 @@ var K8sGetInterval = 100 * time.Millisecond
 
 var testLogger = logf.Log.WithName("test")
 
-//this is used to output stack traces when an error occurs
+// this is used to output stack traces when an error occurs
 func checkError(err error) {
 	if err != nil {
 		testLogger.Error(errors.Wrap(err, 0), "test failure")


### PR DESCRIPTION
This PR updates comments which are not compliant and keep getting updated when `dlv` is running for debugging test.