### PR TITLE
Fix a link url and test to folder to run in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,13 @@ test: generate fmt vet manifests
 	test -f $(ENVTEST_ASSETS_DIR)/setup-envtest.sh || curl -sSLo $(ENVTEST_ASSETS_DIR)/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.6.3/hack/setup-envtest.sh
 	source $(ENVTEST_ASSETS_DIR)/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out -v --ginkgo.flake-attempts=2
 
+# Debug xjoin.v1 tests
+delve-test: generate fmt vet manifests
+	mkdir -p $(ENVTEST_ASSETS_DIR)
+	test -f $(ENVTEST_ASSETS_DIR)/setup-envtest.sh || curl -sSLo $(ENVTEST_ASSETS_DIR)/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.6.3/hack/setup-envtest.sh
+	source $(ENVTEST_ASSETS_DIR)/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); which dlv; dlv version; dlv test ./controllers/test --headless --accept-multiclient --listen=:2345 --api-version=2 -- --ginkgo.flake-attempts=2
+
+# Debug xjoin.v2 tests
 delve-test: generate fmt vet manifests
 	mkdir -p $(ENVTEST_ASSETS_DIR)
 	test -f $(ENVTEST_ASSETS_DIR)/setup-envtest.sh || curl -sSLo $(ENVTEST_ASSETS_DIR)/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.6.3/hack/setup-envtest.sh

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ test: generate fmt vet manifests
 delve-test: generate fmt vet manifests
 	mkdir -p $(ENVTEST_ASSETS_DIR)
 	test -f $(ENVTEST_ASSETS_DIR)/setup-envtest.sh || curl -sSLo $(ENVTEST_ASSETS_DIR)/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.6.3/hack/setup-envtest.sh
-	source $(ENVTEST_ASSETS_DIR)/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); which dlv; dlv version; dlv test ./controllers/test --headless --accept-multiclient --listen=:2345 --api-version=2 -- --ginkgo.flake-attempts=2
+	source $(ENVTEST_ASSETS_DIR)/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); which dlv; dlv version; dlv test ./controllers --headless --accept-multiclient --listen=:2345 --api-version=2 -- --ginkgo.flake-attempts=2
 
 # Generic tests using latest operator-sdk patterns
 LOCALBIN ?= $(shell pwd)/bin

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ delve-test: generate fmt vet manifests
 	source $(ENVTEST_ASSETS_DIR)/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); which dlv; dlv version; dlv test ./controllers/test --headless --accept-multiclient --listen=:2345 --api-version=2 -- --ginkgo.flake-attempts=2
 
 # Debug xjoin.v2 tests
-delve-test: generate fmt vet manifests
+debug-v2-tests: generate fmt vet manifests
 	mkdir -p $(ENVTEST_ASSETS_DIR)
 	test -f $(ENVTEST_ASSETS_DIR)/setup-envtest.sh || curl -sSLo $(ENVTEST_ASSETS_DIR)/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.6.3/hack/setup-envtest.sh
 	source $(ENVTEST_ASSETS_DIR)/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); which dlv; dlv version; dlv test ./controllers --headless --accept-multiclient --listen=:2345 --api-version=2 -- --ginkgo.flake-attempts=2

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 XJoin (Cross Join) Operator
 ==============
 
-Openshift operator that manages the [XJoin pipeline](https://clouddot.pages.redhat.com/docs/dev/services/xjoin.html).
+Openshift operator that manages the [XJoin pipeline](https://consoledot.pages.redhat.com/docs/dev/services/xjoin.html).
 It currently manages version 1 of XJoin,
 i.e. it maintains the replication pipeline between HBI and ElasticSearch.
 Modifications will be necessary to support [version 2](#version-2) (joining data between applications).


### PR DESCRIPTION
This PR updates link to the `XJoin pipeline` doc page.  It also changes the `delve-test` target in makefile to run the tests in the `contollers` folder and not just the ones in `controllers/test`