### PR TITLE
remove hard coded project name.  Should provide one

### DIFF
--- a/dev/forward-ports-clowder.sh
+++ b/dev/forward-ports-clowder.sh
@@ -5,7 +5,8 @@ pkill -f "kubectl port-forward"
 PROJECT_NAME=$1
 
 if [ -z "$PROJECT_NAME" ]; then
-  PROJECT_NAME="test"
+  echo "openshift project or Kubernetes namespace required as input argument." 
+  exit(1)
 fi
 
 echo "Using namespace $PROJECT_NAME"
@@ -28,7 +29,7 @@ kubectl port-forward "$CONNECT_SVC" 8083:8083 -n "$PROJECT_NAME" >/dev/null 2>&1
 kubectl port-forward "$ELASTICSEARCH_SVC" 9200:9200 -n "$PROJECT_NAME" >/dev/null 2>&1 &
 kubectl port-forward "$KAFKA_SVC" 9092:9092 -n "$PROJECT_NAME" >/dev/null 2>&1 &
 kubectl port-forward "$KAFKA_SVC" 29092:9092 -n "$PROJECT_NAME" >/dev/null 2>&1 &
-#kubectl port-forward "$XJOIN_SVC" 4000:4000 -n "$PROJECT_NAME" >/dev/null 2>&1 &
+kubectl port-forward "$XJOIN_SVC" 4000:4000 -n "$PROJECT_NAME" >/dev/null 2>&1 &
 kubectl port-forward "$HBI_SVC" 8000:8000 -n "$PROJECT_NAME" >/dev/null 2>&1 &
 kubectl port-forward "$APICURIO_SVC" 10001:10000 -n "$PROJECT_NAME" >/dev/null 2>&1 &
 kubectl port-forward "$XJOIN_API_GATEWAY" 10000:10000 -n "$PROJECT_NAME" >/dev/null 2>&1 &


### PR DESCRIPTION
Remove the hard coded project name "test".  Now users must provide one to make the script usable out of the box for ephemeral environments.

It also exposes the graphql port which is required for host-inventory testing