### PR TITLE
Use one service name for elasticsearch instead of two different ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The operator defines two controllers that reconcile a XJoinPipeline
 6. Do one of the following
     - Append the following line into `/etc/hosts`
         ```
-        127.0.0.1 inventory-db host-inventory-db.test.svc xjoin-elasticsearch-es-default.test.svc connect-connect-api.test.svc xjoin-elasticsearch-es-http kafka-kafka-0.kafka-kafka-brokers.test.svc apicurio apicurio.test.svc xjoin-elasticsearch-es-http.test.svc
+        127.0.0.1 inventory-db host-inventory-db.test.svc xjoin-elasticsearch-es-default.test.svc connect-connect-api.test.svc kafka-kafka-0.kafka-kafka-brokers.test.svc apicurio apicurio.test.svc .test.svc
         ```
     - Install and run [kubefwd](https://github.com/txn2/kubefwd)
       ```

--- a/controllers/test/utils_test.go
+++ b/controllers/test/utils_test.go
@@ -2,6 +2,10 @@ package test
 
 import (
 	"context"
+	"os/exec"
+	"reflect"
+	"time"
+
 	"github.com/redhatinsights/xjoin-go-lib/pkg/utils"
 	"github.com/redhatinsights/xjoin-operator/controllers"
 	. "github.com/redhatinsights/xjoin-operator/controllers/config"
@@ -17,11 +21,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
-	"os/exec"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"time"
 )
 
 var log = logger.NewLogger("test_utils")
@@ -71,7 +72,7 @@ func parametersToMap(parameters Parameters) map[string]interface{} {
 
 func getParameters() (Parameters, map[string]interface{}, error) {
 	options := viper.New()
-	options.SetDefault("ElasticSearchURL", "http://xjoin-elasticsearch-es-http.test.svc:9200")
+	options.SetDefault("ElasticSearchURL", "http://xjoin-elasticsearch-es-default.test.svc:9200")
 	options.SetDefault("ElasticSearchUsername", "test")
 	options.SetDefault("ElasticSearchPassword", "test1337")
 	options.SetDefault("HBIDBHost", "host-inventory-db.test.svc")
@@ -176,7 +177,7 @@ func Before() (*Iteration, error) {
 	}
 
 	es, err := elasticsearch.NewElasticSearch(
-		"http://xjoin-elasticsearch-es-http.test.svc:9200",
+		"http://xjoin-elasticsearch-es-default.test.svc:9200",
 		"xjoin",
 		"xjoin1337",
 		ResourceNamePrefix,

--- a/controllers/test/xjoinpipeline_controller_test.go
+++ b/controllers/test/xjoinpipeline_controller_test.go
@@ -2,6 +2,10 @@ package test
 
 import (
 	"fmt"
+	"reflect"
+	"strconv"
+	"time"
+
 	"github.com/redhatinsights/xjoin-go-lib/pkg/utils"
 	xjoin "github.com/redhatinsights/xjoin-operator/api/v1alpha1"
 	"github.com/redhatinsights/xjoin-operator/controllers/database"
@@ -10,9 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/record"
-	"reflect"
-	"strconv"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -92,7 +93,7 @@ var _ = Describe("Pipeline operations", func() {
 			Expect(esConnectorConfig["transforms.flattenListString.sourceField"]).To(Equal("tags"))
 			Expect(esConnectorConfig["auto.create.indices.at.start"]).To(Equal(false))
 			Expect(esConnectorConfig["behavior.on.null.values"]).To(Equal("delete"))
-			Expect(esConnectorConfig["connection.url"]).To(Equal("http://xjoin-elasticsearch-es-http.test.svc:9200"))
+			Expect(esConnectorConfig["connection.url"]).To(Equal("http://xjoin-elasticsearch-es-default.test.svc:9200"))
 			Expect(esConnectorConfig["errors.log.enable"]).To(Equal(true))
 			Expect(esConnectorConfig["max.retries"]).To(Equal(int64(8)))
 			Expect(esConnectorConfig["transforms.deleteIf.field"]).To(Equal("__deleted"))
@@ -650,7 +651,7 @@ var _ = Describe("Pipeline operations", func() {
 			connectorConfig := connectorSpec["config"].(map[string]interface{})
 			Expect(connectorConfig["connection.username"]).To(Equal("test"))
 			Expect(connectorConfig["connection.password"]).To(Equal("test1337"))
-			Expect(connectorConfig["connection.url"]).To(Equal("http://xjoin-elasticsearch-es-http.test.svc:9200"))
+			Expect(connectorConfig["connection.url"]).To(Equal("http://xjoin-elasticsearch-es-default.test.svc:9200"))
 		})
 
 		It("Triggers refresh if index disappears", func() {

--- a/dev/forward-ports-clowder.sh
+++ b/dev/forward-ports-clowder.sh
@@ -14,7 +14,7 @@ KAFKA_NAME=$(kubectl get kafka -o custom-columns=:metadata.name -n "$PROJECT_NAM
 CONNECT_NAME=$(kubectl get kafkaconnect -o custom-columns=:metadata.name -n "$PROJECT_NAME" | xargs)
 KAFKA_SVC="svc/$KAFKA_NAME-kafka-bootstrap"
 CONNECT_SVC="svc/$CONNECT_NAME-connect-api"
-ELASTICSEARCH_SVC="svc/xjoin-elasticsearch-es-http"
+ELASTICSEARCH_SVC="svc/xjoin-elasticsearch-es-default"
 HBI_DB_SVC="svc/host-inventory-db"
 XJOIN_SVC="svc/xjoin-search"
 HBI_SVC="svc/host-inventory-service"

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -153,8 +153,8 @@ if [ "$SETUP_ELASTICSEARCH" = true ] || [ "$SETUP_ALL" = true ]; then
     echo "Unable to get ES_PASSWORD"
   fi
 
-  pkill -f "kubectl port-forward svc/xjoin-elasticsearch-es-http"
-  kubectl port-forward svc/xjoin-elasticsearch-es-http 9200:9200 -n "$PROJECT_NAME" &
+  pkill -f "kubectl port-forward svc/xjoin-elasticsearch-es-default"
+  kubectl port-forward svc/xjoin-elasticsearch-es-default 9200:9200 -n "$PROJECT_NAME" &
   sleep 3
 
   curl -X POST -u "elastic:$ES_PASSWORD" -k "http://localhost:9200/_security/user/xjoin" \


### PR DESCRIPTION
This PR sets elasticsearch service name to `xjoin-elasticsearch-es-default` everywhere and replaces `xjoin-elasticsearch-es-http` wherever it was used.  Using two different names for the same service has the potential to cause confusion to new users who are not intimately familiar to the code.