### PR TITLE
Bumping the go-toolset

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.19.6 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.19 as builder
 
 USER 0
 WORKDIR /workspace
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
-RUN microdnf install --setopt=tsflags=nodocs -y go-toolset-1.19.6 && \
+RUN microdnf install --setopt=tsflags=nodocs -y go-toolset-1.19 && \
     microdnf install -y rsync tar procps-ng && \
     microdnf upgrade -y && \
     microdnf clean all


### PR DESCRIPTION
Changed the go call outs to be x and y and not x, y, and z  (example 1.19 instead of 1.19.6)