### PR TITLE
Specify branch in git actions

### DIFF
--- a/.github/workflows/checkimage.yaml
+++ b/.github/workflows/checkimage.yaml
@@ -26,4 +26,6 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@v4
         with:
+          branch: create-pull-request/base-image
+          delete-branch: true
           title: 'chore(image): update base image'

--- a/.github/workflows/update_mapping.yaml
+++ b/.github/workflows/update_mapping.yaml
@@ -41,6 +41,8 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
+          branch: create-pull-request/update-mapping
+          delete-branch: true
           title: 'chore(update_mapping) Update mapping'
           body: |
             Updated xjoin-operator to support the latest inventory-schemas change


### PR DESCRIPTION
Updates the `update_mapping` and `checkimage` workflows so that they don't step on each others' toes. Right now they attempt to push to the same branch, and since the latest base-image PR wasn't merged, the `update_mapping` workflow sees that PR and decides there's nothing to do.
I also told it to delete its working branch once the PR is merged or closed.