### PR TITLE
Swap out es-mapping for the one used by xjoin-search

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,8 +9,17 @@
       "version": "1.0.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "js-yaml": "^4.1.0",
-        "json-schema-to-es-mapping": "git+https://github.com/RedHatInsights/json-schema-to-es-mapping.git#master"
+        "@ckyrouac/json-schema-to-es-mapping": "^0.3.7",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@ckyrouac/json-schema-to-es-mapping": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@ckyrouac/json-schema-to-es-mapping/-/json-schema-to-es-mapping-0.3.7.tgz",
+      "integrity": "sha512-ThUwRfYTKP9a5dNp0WNJGq+X5fQqsFnebIZmzoxnvQ6Bjm5dSMFO3P+e200U57Dq1ED7+Rp/1Zn6CzMB5/CGMg==",
+      "dependencies": {
+        "dot-prop": "^5.0.0",
+        "inflection": "^1.12.0"
       }
     },
     "node_modules/argparse": {
@@ -55,18 +64,18 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/json-schema-to-es-mapping": {
-      "version": "0.3.6",
-      "resolved": "git+ssh://git@github.com/RedHatInsights/json-schema-to-es-mapping.git#0b6144ef6dfa86d84071bd21cc10eb9dd9fc4adc",
-      "license": "MIT",
-      "dependencies": {
-        "dot-prop": "^5.0.0",
-        "inflection": "^1.12.0"
-      }
     }
   },
   "dependencies": {
+    "@ckyrouac/json-schema-to-es-mapping": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@ckyrouac/json-schema-to-es-mapping/-/json-schema-to-es-mapping-0.3.7.tgz",
+      "integrity": "sha512-ThUwRfYTKP9a5dNp0WNJGq+X5fQqsFnebIZmzoxnvQ6Bjm5dSMFO3P+e200U57Dq1ED7+Rp/1Zn6CzMB5/CGMg==",
+      "requires": {
+        "dot-prop": "^5.0.0",
+        "inflection": "^1.12.0"
+      }
+    },
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -96,14 +105,6 @@
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "requires": {
         "argparse": "^2.0.1"
-      }
-    },
-    "json-schema-to-es-mapping": {
-      "version": "git+ssh://git@github.com/RedHatInsights/json-schema-to-es-mapping.git#0b6144ef6dfa86d84071bd21cc10eb9dd9fc4adc",
-      "from": "json-schema-to-es-mapping@git+https://github.com/RedHatInsights/json-schema-to-es-mapping.git#master",
-      "requires": {
-        "dot-prop": "^5.0.0",
-        "inflection": "^1.12.0"
       }
     }
   }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -10,6 +10,6 @@
   "license": "GPL-3.0-or-later",
   "dependencies": {
     "js-yaml": "^4.1.0",
-    "json-schema-to-es-mapping": "git+https://github.com/RedHatInsights/json-schema-to-es-mapping.git#master"
+    "@ckyrouac/json-schema-to-es-mapping": "^0.3.7"
   }
 }

--- a/scripts/update_mapping.js
+++ b/scripts/update_mapping.js
@@ -3,7 +3,7 @@
 
 const fs = require('fs');
 const yaml = require('js-yaml');
-const { buildMappingsFor } = require("json-schema-to-es-mapping");
+const { buildMappingsFor } = require("@ckyrouac/json-schema-to-es-mapping");
 
 function remove_blocked_fields(schema) {
     for (const [key, value] of Object.entries(schema["properties"])) {


### PR DESCRIPTION
Swaps out the `json-schema-to-es-mapping` dependency for the one used by xjoin-search