### PR TITLE
Update Security Catalog Script with New Tagging Convention

### DIFF
--- a/build_security_catalog.sh
+++ b/build_security_catalog.sh
@@ -2,5 +2,5 @@
 set -e
 
 source build_catalog.sh
-build_a_tag security-compliance
+build_a_tag "sc-$(date +%Y%m%d)-$(git rev-parse --short=7 HEAD)"
 


### PR DESCRIPTION
This PR updates the Security-Compliance Tag Naming Convention within the `build_security_catalog.sh` to make it easier to identify the Git Commit the image is based on.

Example:

OLD: `security-compliance`
NEW: `sc-20230920-f963f6f`