### PR TITLE
task: Remove go-toolset from running image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 # APP IMAGE 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
-RUN microdnf install --setopt=tsflags=nodocs -y go-toolset && \
-    microdnf install -y rsync tar procps-ng && \
+RUN microdnf install -y rsync tar procps-ng && \
     microdnf upgrade -y && \
     microdnf clean all
 


### PR DESCRIPTION
Remove go toolset from the running image. This should be used for dev only and not have an impact on running the actual app.