### PR TITLE
fix: remove unneeded packages from build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,8 @@ COPY controllers/ controllers/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
-
 # APP IMAGE 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-
-RUN microdnf install -y rsync tar procps-ng && \
-    microdnf upgrade -y && \
-    microdnf clean all
 
 WORKDIR /
 COPY --from=builder /workspace/manager .


### PR DESCRIPTION
These packages were used for debugging but are not needed for the app to run