### PR TITLE
Use temp dir for docker config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,9 @@ npm-debug.log
 .env
 .DS_Store
 
+# Potential security risks
+.docker
+.podman
+.kube
+
 tmp/**/*

--- a/Dockerfile.unittest
+++ b/Dockerfile.unittest
@@ -1,5 +1,30 @@
 FROM registry.access.redhat.com/ubi8/go-toolset:1.17.12
 
+USER 0
 WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
 
-COPY . .
+# Copy the go source
+COPY main.go main.go
+COPY api/ api/
+COPY controllers/ controllers/
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+
+
+# APP IMAGE 
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+RUN microdnf install -y rsync tar procps-ng && \
+    microdnf upgrade -y && \
+    microdnf clean all
+
+WORKDIR /
+COPY --from=builder /workspace/manager .
+USER 65534:65534

--- a/build_catalog.sh
+++ b/build_catalog.sh
@@ -48,7 +48,18 @@ function build_a_tag ()
   export PATH=${GOUNPACK}/go/bin:$PATH
 
   # Login to docker
-  export DOCKER_CONFIG="$PWD/.docker"
+  # Create tmp dir to store data in during job run (do NOT store in $WORKSPACE)
+  export TMP_JOB_DIR=$(mktemp -d -p "$HOME" -t "jenkins-${JOB_NAME}-${BUILD_NUMBER}-XXXXXX")
+  echo "job tmp dir location: $TMP_JOB_DIR"
+
+  function job_cleanup() {
+      echo "cleaning up job tmp dir: $TMP_JOB_DIR"
+      rm -fr $TMP_JOB_DIR
+  }
+
+  trap job_cleanup EXIT ERR SIGINT SIGTERM
+
+  DOCKER_CONF="$TMP_JOB_DIR/.docker"
   mkdir -p "$DOCKER_CONFIG"
 
   docker login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io

--- a/dev/demo/Dockerfile
+++ b/dev/demo/Dockerfile
@@ -1,9 +1,0 @@
-FROM python:3.10.2
-
-COPY . .
-
-RUN pip install --upgrade pip && \
-    pip install pipenv && \
-    pipenv install --system --deploy --ignore-pipfile
-
-CMD bash -c 'alembic upgrade head'


### PR DESCRIPTION
Uses a temp dir for the docker config to keep it out of the workspace. Also removes instances of `COPY . .` from the Dockerfiles.