### PR TITLE
Revert "fix: Remove go toolset from running image"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 # APP IMAGE 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
-RUN microdnf install -y rsync tar procps-ng && \
+RUN microdnf install --setopt=tsflags=nodocs -y go-toolset && \
+    microdnf install -y rsync tar procps-ng && \
     microdnf upgrade -y && \
     microdnf clean all
 


### PR DESCRIPTION
Reverts RedHatInsights/xjoin-operator#181
It looks suspiciously like this broke the PR checks, so I want to try reverting this. If it remains broken, I'll revert this.