### PR TITLE
Use insights_kafka_connect in xjoin namespaces instead of xjoin-kafka-connect-strimzi

### DIFF
--- a/deploy/pipeline.yml
+++ b/deploy/pipeline.yml
@@ -11,7 +11,7 @@ parameters:
   - name: CONNECT_CLUSTER_NAMESPACE
     value: "xjoin-stage"
   - name: CONNECT_CLUSTER
-    value: "xjoin-kafka-connect-strimzi"
+    value: "insights-kafka-connect"
   - name: KAFKA_CLUSTER
     value: "platform-mq"
   - name: MANAGED_KAFKA


### PR DESCRIPTION
rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED

This PR replaces `xjoin-kafka-connect-strimzi` with the `insights-kafka-connect` provided by the Fedramp/devprod team.  This should fix the problem reported by https://redhat-internal.slack.com/archives/CCRND57FW/p1730349986701199.

A reference to this `operator.yml` was found at https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/services/insights/xjoin/deploy-xjoin-operator.yml#L42